### PR TITLE
Add stable branch

### DIFF
--- a/QUICKSTART.sh
+++ b/QUICKSTART.sh
@@ -81,9 +81,11 @@ cd "$BASEDIR/$WORKINGDIR"
 
 if [ ! -d "tlspool" ]; then
   git clone https://github.com/arpa2/tlspool
+  git checkout 49bf1157e3471ee15bc279d41c9492646a2bf44c
 else 
   cd tlspool
   git pull https://github.com/arpa2/tlspool
+  git checkout 49bf1157e3471ee15bc279d41c9492646a2bf44c
   cd ..
 fi
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,6 +2,8 @@
 TARGETS_OFFLINE = valexprun testvalexp
 TARGETS = $(TARGETS_OFFLINE) onlinecheck testonline
 
+PKG_CONFIG ?= pkg-config
+
 OBJS = *.o
 
 CFLAGS += -pthread -I ../include
@@ -23,14 +25,14 @@ VALEXP_TESTS = $(shell cd data-valexp-in ; ls -1)
 GNUTLS_CFLAGS = $(shell $(PKG_CONFIG) --cflags gnutls)
 GNUTLS_LIBS   = $(shell $(PKG_CONFIG) --libs   gnutls)
 
-P11KIT_CFLAGS = $(shell pkg-config --cflags p11-kit-1)
-P11KIT_LIBS   = $(shell pkg-config --libs   p11-kit-1)
+P11KIT_CFLAGS = $(shell $(PKG_CONFIG) --cflags p11-kit-1)
+P11KIT_LIBS   = $(shell $(PKG_CONFIG) --libs   p11-kit-1)
 
 BDB_CFLAGS = 
 BDB_LDFLAGS = -ldb
 
-QUICKDER_CFLAGS = $(shell pkg-config --cflags quick-der) -ggdb3
-QUICKDER_LIBS   = $(shell pkg-config --libs   quick-der)
+QUICKDER_CFLAGS = $(shell $(PKG_CONFIG) --cflags quick-der) -ggdb3
+QUICKDER_LIBS   = $(shell $(PKG_CONFIG) --libs   quick-der)
 
 all: $(TARGETS)
 


### PR DESCRIPTION
Can we make a "stable" branch for tlspool that will always allow a working setup?
I can then reference that in the QUICKSTART.sh.
Now I've reverted temporarily to last known working version of tlspool so that work can continue.