### PR TITLE
Makefile refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,43 @@ BUILDDIRS=src lib tool pulleyback doc test
 
 .PHONEY: all install clean distclean
 
+# making LIBS/CFLAGS available in all sub-make files
+PKG_CONFIG ?= pkg-config
+KRB_CONFIG ?= krb5-config
+export GNUTLS_CFLAGS   = $(shell $(PKG_CONFIG) --cflags gnutls)
+export GNUTLS_LIBS     = $(shell $(PKG_CONFIG) --libs   gnutls)
+export GNUTLS_CFLAGS  += $(shell $(PKG_CONFIG) --cflags gnutls-dane)
+export GNUTLS_LIBS    += $(shell $(PKG_CONFIG) --libs   gnutls-dane)
+export P11KIT_CFLAGS   = $(shell $(PKG_CONFIG) --cflags p11-kit-1)
+export P11KIT_LIBS     = $(shell $(PKG_CONFIG) --libs   p11-kit-1)
+export TASN1_CFLAGS    = $(shell $(PKG_CONFIG) --cflags libtasn1)
+export TASN1_LIBS      = $(shell $(PKG_CONFIG) --libs   libtasn1)
+export QUICKDER_CFLAGS = $(shell $(PKG_CONFIG) --cflags quick-der)
+export QUICKDER_LIBS   = $(shell $(PKG_CONFIG) --libs   quick-der)
+export KERBEROS_CFLAGS = $(shell $(KRB_CONFIG) --cflags)
+export KERBEROS_LIBS   = $(shell $(KRB_CONFIG) --libs)
+
+# these LIBS are not provided by pkg-config so we need them in a way the OS can override them with an 'export' from a shell
+ifndef UNBOUND_LIBS
+export UNBOUND_LIBS="-lunbound"
+endif
+
+ifndef BDB_LIBS
+export BDB_LIBS="-ldb"
+endif
+
+ifndef LDAP_LIBS
+export LDAP_LIBS="-lldap"
+endif
+
+ifndef LDNS_LIBS
+export LDNS_LIBS="-lldns"
+endif
+
+ifndef SYSTEMD_LIBS
+export SYSTEMD_LIBS="-lsystemd-daemon"
+endif
+
 all:
 	@$(foreach dir,$(BUILDDIRS),$(MAKE) DESTDIR=$(DESTDIR) PREFIX=$(PREFIX) -C '$(dir)' all && ) echo Built all
 	@echo '#'

--- a/pulleyback/Makefile
+++ b/pulleyback/Makefile
@@ -12,8 +12,6 @@ LDFLAGS += -std=gnu11
 BDB_CFLAGS = 
 ifdef WINVER
 BDB_LIBS   = -ldb-6.1
-else
-BDB_LIBS   = -ldb
 endif
 
 PREFIX ?= /usr/local

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,11 +5,11 @@ OBJS = daemon.o config.o manage.o service.o cache.o pinentry.o lidentry.o \
 	validate.o online.o pgp.o trust.o
 
 CFLAGS += -pthread -I ../include -std=gnu11
-CFLAGS += $(GNUTLS_CFLAGS) $(P11KIT_CFLAGS) $(BDB_CFLAGS) $(TASN1_CFLAGS) $(UNBOUND_CFLAGS) $(QUICKDER_CFLAGS) $(NIX_MAGIC_CFLAGS)
+CFLAGS += $(GNUTLS_CFLAGS) $(P11KIT_CFLAGS) $(BDB_CFLAGS) $(TASN1_CFLAGS) $(UNBOUND_CFLAGS) $(QUICKDER_CFLAGS)
 
 LDFLAGS += -std=gnu11
 
-LIBS = $(GNUTLS_LIBS) $(P11KIT_LIBS) $(BDB_LIBS) $(TASN1_LIBS) $(UNBOUND_LIBS) $(QUICKDER_LIBS) $(NIX_MAGIC_LIBS)
+LIBS = $(GNUTLS_LIBS) $(P11KIT_LIBS) $(BDB_LIBS) $(TASN1_LIBS) $(UNBOUND_LIBS) $(QUICKDER_LIBS) 
 LIBS += $(LDNS_LIBS) -lpthread
 
 ifdef WITH_SYSTEMD

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,16 +5,16 @@ OBJS = daemon.o config.o manage.o service.o cache.o pinentry.o lidentry.o \
 	validate.o online.o pgp.o trust.o
 
 CFLAGS += -pthread -I ../include -std=gnu11
-CFLAGS += $(GNUTLS_CFLAGS) $(P11KIT_CFLAGS) $(BDB_CFLAGS) $(TASN1_CFLAGS) $(UNBOUND_CFLAGS) $(QUICKDER_CFLAGS)
+CFLAGS += $(GNUTLS_CFLAGS) $(P11KIT_CFLAGS) $(BDB_CFLAGS) $(TASN1_CFLAGS) $(UNBOUND_CFLAGS) $(QUICKDER_CFLAGS) $(NIX_MAGIC_CFLAGS)
 
 LDFLAGS += -std=gnu11
 
-LIBS = $(GNUTLS_LIBS) $(P11KIT_LIBS) $(BDB_LIBS) $(TASN1_LIBS) $(UNBOUND_LIBS) $(QUICKDER_LIBS)
-LIBS += -lldns -lpthread
+LIBS = $(GNUTLS_LIBS) $(P11KIT_LIBS) $(BDB_LIBS) $(TASN1_LIBS) $(UNBOUND_LIBS) $(QUICKDER_LIBS) $(NIX_MAGIC_LIBS)
+LIBS += $(LDNS_LIBS) -lpthread
 
 ifdef WITH_SYSTEMD
 CFLAGS += -DHAVE_SYSTEMD
-LIBS   += -lsystemd-daemon
+LIBS   += $(SYSTEMD_LIBS) 
 endif
 
 ifndef WITHOUT_KERBEROS
@@ -22,20 +22,9 @@ CFLAGS += -DHAVE_TLS_KDH $(KERBEROS_CFLAGS)
 LIBS += $(KERBEROS_LIBS)
 endif
 
-GNUTLS_CFLAGS = $(shell $(PKG_CONFIG) --cflags gnutls)
-GNUTLS_LIBS   = $(shell $(PKG_CONFIG) --libs   gnutls)
-GNUTLS_CFLAGS += $(shell $(PKG_CONFIG) --cflags gnutls-dane)
-GNUTLS_LIBS   += $(shell $(PKG_CONFIG) --libs   gnutls-dane)
-P11KIT_CFLAGS = $(shell $(PKG_CONFIG) --cflags p11-kit-1)
-P11KIT_LIBS   = $(shell $(PKG_CONFIG) --libs   p11-kit-1)
-TASN1_CFLAGS = $(shell $(PKG_CONFIG) --cflags libtasn1)
-TASN1_LIBS   = $(shell $(PKG_CONFIG) --libs   libtasn1)
-#HOWTOUSE# UNBOUND_FLAGS = $(shell $(PKG_CONFIG) --cflags libunbound)
-#HOWTOUSE# UNBOUND_LIBS  = $(shell $(PKG_CONFIG) --libs   libunbound)
-QUICKDER_CFLAGS = $(shell $(PKG_CONFIG) --cflags quick-der)
-QUICKDER_LIBS   = $(shell $(PKG_CONFIG) --libs   quick-der)
-KERBEROS_CFLAGS = $(shell krb5-config --cflags)
-KERBEROS_LIBS = $(shell krb5-config --libs)
+ifdef DEBUG
+CFLAGS += -g -O0
+endif
 
 ifdef WINVER
 CFLAGS += -D_WIN32_WINNT=0x0600 -DATTRIBUTE_UNUSED="" -I ../include/windows
@@ -44,37 +33,21 @@ LIBS += -lkernel32 -ladvapi32 -lmsvcrt -lwsock32 -lws2_32
 EXE = .exe
 endif
 
-PKG_CONFIG ?= pkg-config
-
 ifdef WINVER
 CFLAGS += -D_WIN32_WINNT=0x0600 -DATTRIBUTE_UNUSED="" -I ../include/windows
 OBJS += windows/syslog.o windows/windows.o windows/getopt.o
 LIBS += -lkernel32 -ladvapi32 -lmsvcrt -lwsock32 -lws2_32 -lwldap32 -lunbound
 EXE = .exe
 else
-LIBS += -lldap
+LIBS += $(LDAP_LIBS)
 endif
-
-PKG_CONFIG ?= pkg-config
 
 SBIN ?= sbin
 
 BDB_CFLAGS = 
 ifdef WINVER
 BDB_LIBS   = -ldb-6.1
-else
-BDB_LIBS   = -ldb # this is the default
 endif
-
-TASN1_CFLAGS = $(shell pkg-config --cflags libtasn1)
-TASN1_LIBS   = $(shell pkg-config --libs   libtasn1)
-#HOWTOUSE# UNBOUND_FLAGS = $(shell pkg-config --cflags libunbound)
-#HOWTOUSE# UNBOUBD_LIBS  = $(shell pkg-config --libs   libunbound)
-QUICKDER_CFLAGS = $(shell pkg-config --cflags quick-der)
-QUICKDER_LIBS = $(shell pkg-config --libs quick-der)
-KERBEROS_CFLAGS = $(shell krb5-config --cflags)
-KERBEROS_LIBS = $(shell krb5-config --libs)
-# CFLAGS += -DHAVE_TLS_KDH
 
 all: $(TARGETS)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -31,7 +31,7 @@ P11KIT_CFLAGS = $(shell $(PKG_CONFIG) --cflags p11-kit-1)
 P11KIT_LIBS   = $(shell $(PKG_CONFIG) --libs   p11-kit-1)
 
 BDB_CFLAGS = 
-BDB_LDFLAGS = -ldb
+BDB_LDFLAGS = $(BDB_LIBS)
 
 QUICKDER_CFLAGS = $(shell $(PKG_CONFIG) --cflags quick-der) -ggdb3
 QUICKDER_LIBS   = $(shell $(PKG_CONFIG) --libs   quick-der)
@@ -56,13 +56,13 @@ testvalexp: valexprun
 	@ echo All validation expression tests succeeded
 
 onlinecheck: onlinecheck.c ../src/online.c ../src/config.c ../src/pgp.c
-	gcc $(CFLAGS) $(GNUTLS_CFLAGS) $(QUICKDER_CFLAGS) $(config_CFLAGS) -o "$@" "$<" ../src/pgp.c ../src/config.c -lunbound -lldns -lldap $(GNUTLS_LIBS) $(QUICKDER_LIBS)
+	gcc $(CFLAGS) $(GNUTLS_CFLAGS) $(QUICKDER_CFLAGS) $(config_CFLAGS) -o "$@" "$<" ../src/pgp.c ../src/config.c $(UNBOUND_LIBS) $(LDNS_LIBS) $(LDAP_LIBS) $(GNUTLS_LIBS) $(QUICKDER_LIBS)
 
 testonline: onlinecheck
 	./onlinecheck ../etc/tlspool.conf | tee | grep -v 'UNEXPECTED OUTPUT FAILURE'
 
 pulleybacksimu: pulleybacksimu.c
-	@# gcc $(CFLAGS) -o "$@" "$<" ../pulleyback/api.o ../pulleyback/parse.o ../pulleyback/connect.o ../pulleyback/update.o -lquickder -ldb
+	@# gcc $(CFLAGS) -o "$@" "$<" ../pulleyback/api.o ../pulleyback/parse.o ../pulleyback/connect.o ../pulleyback/update.o -lquickder $(BDB_LDFLAGS)
 	gcc $(CFLAGS) -o "$@" "$<" ../pulleyback/pulleyback_tlspool.so
 
 clean:

--- a/tool/Makefile
+++ b/tool/Makefile
@@ -18,8 +18,16 @@ LIBS =
 
 PREFIX = /usr/local
 
+DIR := ${CURDIR}
+LIBDIR := ""
+ifndef DESTDIR
+	LIBDIR=$(DIR)/../lib/
+else
+	LIBDIR=$(DESTDIR)/lib
+endif
+
 tlspool_LIB = ../lib/libtlspool.so
-tlspool_LDFLAGS = -L ../lib -ltlspool
+tlspool_LDFLAGS = -L ../lib -ltlspool -Wl,-rpath,$(LIBDIR)
 
 donai_CFLAGS = -DDONAI_ONLY_TEXTPROC
 donai_SRC = ../src/donai.c
@@ -87,7 +95,7 @@ pgp11_genkey: pgp11_genkey.c
 	gcc -std=gnu11 $(CFLAGS) $(pgp11genkey_CFLAGS) -o "$@" "$<" $(pgp11genkey_LIBS)
 
 configvar: configvar.c $(tlspool_LIB)
-	gcc -std=gnu11 $(CFLAGS) $(configvar_CFLAGS) -o "$@" "$<" $(configvar_LIBS)
+	gcc -std=gnu11 $(CFLAGS) $(configvar_CFLAGS) -o "$@" "$<"
 
 $(tlspool_LIB):
 	$(MAKE) -C ../lib `basename $(tlspool_LIB)`

--- a/tool/Makefile
+++ b/tool/Makefile
@@ -12,6 +12,10 @@ OBJS = *.o
 
 CFLAGS += -pthread -I ../include
 
+ifdef DEBUG
+CFLAGS += -g -O0
+endif
+
 LDFLAGS =
 
 LIBS = 

--- a/tool/Makefile
+++ b/tool/Makefile
@@ -27,14 +27,14 @@ donai_SRC = ../src/donai.c
 pgp11genkey_CFLAGS = $(P11KIT_CFLAGS)
 pgp11genkey_LIBS = $(P11KIT_LIBS) -lcrypto
 
-configvar_CFLAGS = 
+configvar_CFLAGS = $(tlspool_LDFLAGS)
 configvar_LIBS = $(tlspool_LIB)
 
 P11KIT_CFLAGS = $(shell pkg-config --cflags p11-kit-1)
 P11KIT_LIBS   = $(shell pkg-config --libs   p11-kit-1)
 
 BDB_CFLAGS = 
-BDB_LDFLAGS = -ldb
+BDB_LDFLAGS = $(BDB_LIBS)
 
 all: $(TARGETS)
 


### PR DESCRIPTION
after the fruitful discussion here: https://github.com/arpa2/tlspool/issues/54

this is now the PR to the issue1 and issue3.

i've tested it with:

* nixos-rebuild -I nixpkgs=/root/nixpkgs switch
* nix-shell /root/nixpkgs/default.nix -I nixpkgs=/root/nixpkgs -A tlspool

both compile and probably work. i've tested tlspool/testcli/testsrv with ldd and all symbols are there.

@vanrein 
please do a carefull review since it is already late and i might also have missed something. thanks for your excellent comments in https://github.com/arpa2/tlspool/issues/54 on the topic. except for the RPATH you will probably like this PR very much. 
