### PR TITLE
Fix build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ OBJS = daemon.o config.o manage.o service.o cache.o pinentry.o lidentry.o \
 	validate.o online.o pgp.o trust.o
 
 CFLAGS += -pthread -I ../include -std=gnu11
-CFLAGS += $(GNUTLS_CFLAGS) $(P11KIT_CFLAGS) $(BDB_CFLAGS) $(TASN1_CFLAGS) $(UNBOUND_CFLAGS) $(QUICKDER_CFLAGS)
+CFLAGS += $(BDB_CFLAGS) $(GNUTLS_CFLAGS) $(P11KIT_CFLAGS) $(TASN1_CFLAGS) $(UNBOUND_CFLAGS) $(QUICKDER_CFLAGS)
 
 LDFLAGS += -std=gnu11
 
@@ -61,7 +61,7 @@ PKG_CONFIG ?= pkg-config
 
 SBIN ?= sbin
 
-BDB_CFLAGS =
+BDB_CFLAGS ?=
 ifdef WINVER
 BDB_LIBS   = -ldb-6.1
 else

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,6 +38,7 @@ QUICKDER_CFLAGS = $(shell $(PKG_CONFIG) --cflags Quick-DER)
 QUICKDER_LIBS   = $(shell $(PKG_CONFIG) --libs   Quick-DER)
 KERBEROS_CFLAGS = $(shell krb5-config --cflags)
 KERBEROS_LIBS = $(shell krb5-config --libs)
+# CFLAGS += -DHAVE_TLS_KDH
 
 ifdef WINVER
 CFLAGS += -D_WIN32_WINNT=0x0600 -DATTRIBUTE_UNUSED="" -I ../include/windows
@@ -67,16 +68,6 @@ BDB_LIBS   = -ldb-6.1
 else
 BDB_LIBS   = -ldb # this is the default
 endif
-
-TASN1_CFLAGS = $(shell pkg-config --cflags libtasn1)
-TASN1_LIBS   = $(shell pkg-config --libs   libtasn1)
-#HOWTOUSE# UNBOUND_FLAGS = $(shell pkg-config --cflags libunbound)
-#HOWTOUSE# UNBOUBD_LIBS  = $(shell pkg-config --libs   libunbound)
-QUICKDER_CFLAGS = $(shell pkg-config --cflags Quick-DER)
-QUICKDER_LIBS = $(shell pkg-config --libs Quick-DER)
-KERBEROS_CFLAGS = $(shell krb5-config --cflags)
-KERBEROS_LIBS = $(shell krb5-config --libs)
-# CFLAGS += -DHAVE_TLS_KDH
 
 all: $(TARGETS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,8 +34,8 @@ TASN1_LIBS   = $(shell $(PKG_CONFIG) --libs   libtasn1)
 #HOWTOUSE# UNBOUND_LIBS  = $(shell $(PKG_CONFIG) --libs   libunbound)
 UNBOUND_CFLAGS =
 UNBOUND_LIBS = -lunbound
-QUICKDER_CFLAGS = $(shell $(PKG_CONFIG) --cflags quick-der)
-QUICKDER_LIBS   = $(shell $(PKG_CONFIG) --libs   quick-der)
+QUICKDER_CFLAGS = $(shell $(PKG_CONFIG) --cflags Quick-DER)
+QUICKDER_LIBS   = $(shell $(PKG_CONFIG) --libs   Quick-DER)
 KERBEROS_CFLAGS = $(shell krb5-config --cflags)
 KERBEROS_LIBS = $(shell krb5-config --libs)
 
@@ -61,7 +61,7 @@ PKG_CONFIG ?= pkg-config
 
 SBIN ?= sbin
 
-BDB_CFLAGS = 
+BDB_CFLAGS =
 ifdef WINVER
 BDB_LIBS   = -ldb-6.1
 else
@@ -72,8 +72,8 @@ TASN1_CFLAGS = $(shell pkg-config --cflags libtasn1)
 TASN1_LIBS   = $(shell pkg-config --libs   libtasn1)
 #HOWTOUSE# UNBOUND_FLAGS = $(shell pkg-config --cflags libunbound)
 #HOWTOUSE# UNBOUBD_LIBS  = $(shell pkg-config --libs   libunbound)
-QUICKDER_CFLAGS = $(shell pkg-config --cflags quick-der)
-QUICKDER_LIBS = $(shell pkg-config --libs quick-der)
+QUICKDER_CFLAGS = $(shell pkg-config --cflags Quick-DER)
+QUICKDER_LIBS = $(shell pkg-config --libs Quick-DER)
 KERBEROS_CFLAGS = $(shell krb5-config --cflags)
 KERBEROS_LIBS = $(shell krb5-config --libs)
 # CFLAGS += -DHAVE_TLS_KDH

--- a/src/donai.c
+++ b/src/donai.c
@@ -58,7 +58,7 @@ int dbcred_flags (DBT *creddata, uint32_t *flags) {
  *  - a (data,size) structure for the public credential, also when LID_CHAINED
  * The function returns non-zero on success (zero indicates syntax error).
  */
-int dbcred_interpret (pool_datum_t *creddata, uint32_t *flags, char **p11priv, uint8_t **pubdata, int *pubdatalen) {
+int dbcred_interpret (pool_datum_t *creddata, uint32_t *flags, char **p11priv, uint8_t **pubdata, unsigned int *pubdatalen) {
 	int p11privlen;
 	if (creddata->size <= 4) {
 		return 0;

--- a/src/donai.h
+++ b/src/donai.h
@@ -195,7 +195,7 @@ int dbcred_iterate_next (DBC *opt_crs_disclose, DBC *crs_localid, DBT *opt_discp
  *  - a (data,size) structure for the public credential
  * The function returns non-zero on success (zero indicates syntax error).
  */
-int dbcred_interpret (pool_datum_t *creddata, uint32_t *flags, char **p11priv, uint8_t **pubdata, int *pubdatalen);
+int dbcred_interpret (pool_datum_t *creddata, uint32_t *flags, char **p11priv, uint8_t **pubdata, unsigned int *pubdatalen);
 
 
 /* Iterate over selector values that would generalise the donai.  The

--- a/src/online.c
+++ b/src/online.c
@@ -538,7 +538,7 @@ printf ("DNS IP query type is neither A nor AAAA\n");
 		return ONLINE_INVALID;
 	}
 	// Deliver the response (dta->dnsip_addrfam has already been set)
-	dta->dnsip_addr = dta->dnsip->data [dta->dnsip_next++];
+	dta->dnsip_addr = (uint8_t *)(dta->dnsip->data [dta->dnsip_next++]);
 	return ONLINE_SUCCESS;
 }
 static int dns_ip_first (crsval_t crs, online_data_t dta, val_t hdl, char *param) {
@@ -601,7 +601,7 @@ static void dns_srv_clean (crsval_t crs, online_data_t dta, val_t hdl) {
 }
 static int dns_srv_next (crsval_t crs, online_data_t dta, val_t hdl) {
 	int retval;
-	uint8_t *data;
+	char *data;
 	int len;
 	ldns_rdf *server_rdf;
 	// Load the next element and return if it is non-existent
@@ -715,7 +715,7 @@ static int dns_tlsa_next (crsval_t crs, online_data_t dta, val_t hdl) {
 	uint8_t *data;
 	int len;
 	// Load the next element and return if it is non-existent
-	data = dta->dnstlsa->data [dta->dnstlsa_next];
+	data = (uint8_t *)(dta->dnstlsa->data [dta->dnstlsa_next]);
 	if (data == NULL) {
 		return ONLINE_NOTFOUND;
 	}

--- a/src/online.c
+++ b/src/online.c
@@ -316,7 +316,7 @@ int online_run_profile (online_profile_t *prf,
  * The return value is the number of characters added; this may be more than
  * the dstlen, but then the copy hasn't been executed.
  */
-int strncatesc (char *dst, int dstlen, char *src, char srcend, char *escme) {
+int strncatesc (char *dst, int dstlen, const char *src, char srcend, const char *escme) {
 	int retval = 0;
 	int esc;
 	char *stacked = NULL;

--- a/src/online.c
+++ b/src/online.c
@@ -1069,7 +1069,7 @@ static int ldap_getattr_first (crsval_t crs, online_data_t dta, val_t hdl, char 
 static int ldap_attrcmp_eval (online_data_t dta, val_t hdl, char *param) {
 	assert (dta->ldap != NULL);
 	assert (dta->ldap_attr != NULL);
-	void *cursor;
+	struct berelement *cursor;
 	char *atnm;
 	struct berval **atvs;
 	int i;
@@ -1100,7 +1100,7 @@ printf ("LDAP attribute comparison match is %d\n", match);
 static int ldap_pgpkeycmp_eval (online_data_t dta, val_t hdl, char *param) {
 	assert (dta->ldap != NULL);
 	assert (dta->ldap_attr != NULL);
-	void *cursor;
+	struct berelement *cursor;
 	char *atnm;
 	struct berval **atvs;
 	int i;

--- a/src/online.c
+++ b/src/online.c
@@ -336,7 +336,7 @@ int strncatesc (char *dst, int dstlen, char *src, char srcend, char *escme) {
 		retval += esc ? 3 : 1;
 		if (retval <= dstlen) {
 			if (esc) {
-				sprintf (dst, "\\02x", *src++);
+				sprintf (dst, "\\%02x", *src++);
 				dst += 3;
 			} else {
 				*dst++ = *src++;

--- a/src/pgp.c
+++ b/src/pgp.c
@@ -50,7 +50,7 @@ bool pgp_initcursor_radix64 (pgpcursor_t crs, char *data, uint32_t len) {
 		return 0;
 	}
 	// Setup initial data
-	crs->ptr = data;
+	crs->ptr = (uint8_t *)data;
 	crs->ofs = 0;
 	crs->r64ofs = r64ofs;
 	// Count the characters of radix64; look for '-' and '=' endings

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -1525,7 +1525,7 @@ fprintf (stderr, "DEBUG: Missing certificate for local ID %s and remote ID %s\n"
 	//
 	// Return the overral error code, hopefully GNUTLS_E_SUCCESS
 	tlog (TLOG_TLS, LOG_DEBUG, "Returning %d / %s from clisrv_cert_retrieve()", gtls_errno, gnutls_strerror (gtls_errno));
-fprintf (stderr, "DEBUG: clisrv_cert_retrieve() sets *pcert to 0x%xl (length %d)... {pubkey = 0x%lx, cert= {data = 0x%lx, size=%ld}, type=%ld}\n", (long) *pcert, *pcert_length, (long) (*pcert)->pubkey, (long) (*pcert)->cert.data, (long) (*pcert)->cert.size, (long) (*pcert)->type);
+fprintf (stderr, "DEBUG: clisrv_cert_retrieve() sets *pcert to 0x%lx (length %d)... {pubkey = 0x%lx, cert= {data = 0x%lx, size=%ld}, type=%ld}\n", (long) *pcert, *pcert_length, (long) (*pcert)->pubkey, (long) (*pcert)->cert.data, (long) (*pcert)->cert.size, (long) (*pcert)->type);
 	return gtls_errno;
 }
 

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -3915,7 +3915,7 @@ static int srv_clienthello (gnutls_session_t session, unsigned int htype, unsign
 	int gtls_errno = GNUTLS_E_SUCCESS;
 	char sni [sizeof (cmd->cmd.pio_data.pioc_starttls.remoteid)]; // static
 	size_t snilen = sizeof (sni);
-	int snitype;
+	unsigned int snitype;
 	char *lid;
 
 tlog (LOG_DAEMON, LOG_INFO, "Invoked %sprocessor for Client Hello, htype=%d, incoming=%d\n",

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -1459,7 +1459,8 @@ fprintf (stderr, "DEBUG: Missing certificate for local ID %s and remote ID %s\n"
 			//
 			// When not in user-to-user mode, deliver DER NULL
 			if (!u2u) {
-				certdatum.data = "\x05\x00";
+				static unsigned char der_null_data[] = "\x05\x00";
+				certdatum.data = der_null_data;
 				certdatum.size = 2;
 				E_g2e ("Failed to withhold Kerberos server ticket",
 					gnutls_pcert_import_krb_raw (

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -862,7 +862,7 @@ fprintf (stderr, "DEBUG: gtls_errno==%d after failing to open file for onthefly_
 					GNUTLS_E_FILE_ERROR);
 			} else {
 				gnutls_datum_t cd = {
-					.data = crt,
+					.data = (unsigned char *)(&crt[0]),
 					.size = len
 				};
 fprintf (stderr, "DEBUG: gtls_errno==%d before importing onthefly_issuercrt\n", gtls_errno);
@@ -1136,7 +1136,7 @@ gtls_error clisrv_cert_retrieve (gnutls_session_t session,
 	char *rolestr;
 	char sni [sizeof (cmd->cmd.pio_data.pioc_starttls.localid)];
 	size_t snilen = sizeof (sni);
-	int snitype;
+	unsigned int snitype;
 	int ok;
 	uint32_t flags;
 	char *p11priv;

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -5582,7 +5582,7 @@ gtls_error certificate_onthefly (struct command *cmd) {
 		restsz = cmd->lids [LID_TYPE_X509 - LID_TYPE_MIN].size - 4 - strlen (onthefly_p11uri) - 1;
 		E_g2e ("Failed to export on-the-fly certificate as a credential",
 			gnutls_x509_crt_export (otfcert, GNUTLS_X509_FMT_DER, ptr, &restsz));
-char *pembuf [10000];
+char pembuf [10000];
 size_t pemlen = sizeof (pembuf) - 1;
 int exporterror = gnutls_x509_crt_export (otfcert, GNUTLS_X509_FMT_PEM, pembuf, &pemlen);
 if (exporterror == 0) {

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -3446,7 +3446,7 @@ static gtls_error fetch_remote_credentials (struct command *cmd) {
 	// Note: server's certs _may_ be DER NULL due to mutual auth in Kerberos
 #else
 	cmd->remote_cert_type = gnutls_certificate_type_get (cmd->session);
-	certs = gnutls_certificate_get (cmd->session, &num_certs);
+	certs = gnutls_certificate_get_peers (cmd->session, &num_certs);
 #endif
 	if (certs == NULL) {
 		num_certs = 0;

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -1623,7 +1623,7 @@ gnutls_pcert_st *load_certificate_chain (uint32_t flags, unsigned int *chainlen,
 		long nextlen;
 		// Note: Accept BER because the outside SEQUENCE is not signed
 		certlen = asn1_get_length_ber (
-			((char *) certdatum->data) + 1,
+			(certdatum->data) + 1,
 			certdatum->size,
 			&lenlen);
 		certlen += 1 + lenlen;
@@ -1637,11 +1637,11 @@ gnutls_pcert_st *load_certificate_chain (uint32_t flags, unsigned int *chainlen,
 			*chainlen = 0;
 			return NULL;
 		}
-		nextdatum.data = ((char *) certdatum->data) + certlen;
-		nextdatum.size =           certdatum->size  - certlen;
+		nextdatum.data = (certdatum->data) + certlen;
+		nextdatum.size =  certdatum->size  - certlen;
 		certdatum->size = certlen;
 		nextlen = asn1_get_length_ber (
-			((char *) nextdatum.data) + 1,
+			nextdatum.data + 1,
 			nextdatum.size,
 			&lenlen);
 		nextlen += 1 + lenlen;

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -706,7 +706,7 @@ int gnutls_token_callback (void *const userdata,
 		return GNUTLS_E_PKCS11_TOKEN_ERROR;
 	}
 }
- 
+
 
 /*
  * Implement the GnuTLS function for PIN callback.  This function calls
@@ -1487,8 +1487,8 @@ fprintf (stderr, "DEBUG: Missing certificate for local ID %s and remote ID %s\n"
 			if (status < 2) {
 				gtls_errno = GNUTLS_E_NO_CERTIFICATE_FOUND;
 			} else if (0 != krb5_copy_principal (
-						krbctx_srv, 
-						tgt->server, 
+						krbctx_srv,
+						tgt->server,
 						&cmd->krbid_srv)) {
 				gtls_errno = GNUTLS_E_NO_CERTIFICATE_FOUND;
 			}
@@ -1803,7 +1803,7 @@ static int setup_starttls_kerberos (void) {
 
 
 /* Cleanup Kerberos resources.  This must be an idempotent function, because
- * it is called when Kerberos panics as well as when 
+ * it is called when Kerberos panics as well as when
  */
 #ifdef HAVE_TLS_KDH
 static void cleanup_starttls_kerberos (void) {
@@ -2881,7 +2881,7 @@ static void valexp_1_start (void *vcmd, struct valexp *ve, char pred) {
 /* valexp_I_start -- validation function for the GnuTLS backend.
  * This function ensures that the remote peer provides an identity.
  * TODO: We should compare the hostname as well, or compare if in remoteid
- * TODO: We may need to support more than just X509/PGP certificates 
+ * TODO: We may need to support more than just X509/PGP certificates
  */
 static void valexp_I_start (void *vcmd, struct valexp *ve, char pred) {
 	struct command *cmd = (struct command *) vcmd;
@@ -3068,7 +3068,7 @@ static void valexp_Dd_start (void *vcmd, struct valexp *ve, char pred) {
 	case IPPROTO_SCTP:
 		proto = "sctp";
 		break;
-#endif		
+#endif
 	default:
 		goto setflagval;
 	}
@@ -3942,7 +3942,7 @@ fprintf (stderr, "DEBUG: Got errno = %d / %s at %d\n", errno, strerror (errno), 
 	E_g2e ("Failed to reconfigure GnuTLS as a server",
 		configure_session (cmd,
 			session,
-			srv_creds, srv_credcount, 
+			srv_creds, srv_credcount,
 			cmd->anonpre & ANONPRE_SERVER));
 fprintf (stderr, "DEBUG: Got gtls_errno = %d at %d\n", gtls_errno, __LINE__);
 
@@ -4711,7 +4711,7 @@ fprintf (stderr, "DEBUG: Configuring client credentials\n");
 			configure_session (cmd,
 				session,
 				anonpost? NULL: cli_creds,
-				anonpost?    0: cli_credcount, 
+				anonpost?    0: cli_credcount,
 				cmd->anonpre & ANONPRE_CLIENT));
 	}
 	//
@@ -4739,7 +4739,7 @@ fprintf (stderr, "DEBUG: Configuring server credentials (because it is not a cli
 				configure_session (cmd,
 					session,
 					anonpost? NULL: srv_creds,
-					anonpost?    0: srv_credcount, 
+					anonpost?    0: srv_credcount,
 					cmd->anonpre & ANONPRE_SERVER));
 		}
 #endif
@@ -4941,7 +4941,7 @@ fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
 			//TODO:ELSEWHERE// E_g2e ("Failed to reconfigure GnuTLS without anonymous precursor",
 				//TODO:ELSEWHERE// configure_session (cmd,
 					//TODO:ELSEWHERE// session,
-					//TODO:ELSEWHERE// NULL, 0, 
+					//TODO:ELSEWHERE// NULL, 0,
 					//TODO:ELSEWHERE// 0));
 			// We do not want to use ANON-DH if the flag
 			// ANONPRE_EXTEND_MASTER_SECRET is set for the protocol
@@ -5305,7 +5305,7 @@ fprintf (stderr, "gnutls_deinit (0x%x) at %d\n", session, __LINE__);
 
 
 /*
- * The starttls function responds to an application's request to 
+ * The starttls function responds to an application's request to
  * setup TLS for a given file descriptor, and return a file descriptor
  * with the unencrypted view when done.  The main thing done here is to
  * spark off a new thread that handles the operations.
@@ -5455,7 +5455,7 @@ gtls_error certificate_onthefly (struct command *cmd) {
 		cmd->lids [LID_TYPE_X509 - LID_TYPE_MIN].data = NULL;
 		cmd->lids [LID_TYPE_X509 - LID_TYPE_MIN].size = 0;
 	}
-	
+
 	//
 	// Create an empty certificate
 	E_g2e ("Failed to initialise on-the-fly certificate",

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -5058,6 +5058,7 @@ fprintf (stderr, "DEBUG: Freeing cmd->lids[%d].data %p\n", i-LID_TYPE_MIN, (void
 		free (cmd->trust_valexp);
 		cmd->trust_valexp = NULL;
 	}
+#ifdef HAVE_TLS_KDH
 	//
 	// Cleanup any Kerberos session key -- it served its purpose
 	if (cmd->krb_key.contents != NULL) {
@@ -5075,6 +5076,7 @@ fprintf (stderr, "DEBUG: Freeing cmd->lids[%d].data %p\n", i-LID_TYPE_MIN, (void
 		krb5_free_principal (krbctx_srv, cmd->krbid_cli);
 		cmd->krbid_cli = NULL;
 	}
+#endif
 
 #if 0
 /* This is not proper.  gnutls_certificate_set_key() suggests that these are

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -3772,7 +3772,7 @@ fprintf (stderr, "DEBUG: otfcert retrieval returned GNUTLS_E_AGAIN, so skip it\n
 			// Move the credential into the command structure
 			dbt_store (&creddata,
 				&cmd->lids [lidtype - LID_TYPE_MIN]);
-fprintf (stderr, "DEBUG: Storing cmd->lids[%d].data 0x%016x\n", lidtype-LID_TYPE_MIN, cmd->lids [lidtype-LID_TYPE_MIN].data);
+fprintf (stderr, "DEBUG: Storing cmd->lids[%d].data %p\n", lidtype-LID_TYPE_MIN, cmd->lids [lidtype-LID_TYPE_MIN].data);
 			found = 1;
 		} else {
 			// Skip the credential by freeing its data structure
@@ -4428,7 +4428,7 @@ fprintf (stderr, "DEBUG: Got a request to renegotiate existing TLS connection\n"
 		//
 		// First find the ctlkeynode_tls
 		ckn = (struct ctlkeynode_tls *) ctlkey_find (cmd->cmd.pio_data.pioc_starttls.ctlkey, security_tls, cmd->clientfd);
-fprintf (stderr, "DEBUG: Got ckn == 0x%0x\n", (intptr_t) ckn);
+fprintf (stderr, "DEBUG: Got ckn == %p\n", (void *) ckn);
 		if (ckn == NULL) {
 			tlog (TLOG_UNIXSOCK, LOG_ERR, "Failed to find TLS connection for renegotiation by its ctlkey");
 			send_error (replycmd, ESRCH, "Cannot find TLS connection for renegotiation");
@@ -4478,7 +4478,7 @@ fprintf (stderr, "DEBUG: pthread_join returned %d\n", errno);
 	// that TLS has in this respect.  Maybe we'll capture it one giant loop
 	// at some point, but for now that does not seem to add any relief.
 	renegotiate:
-fprintf (stderr, "DEBUG: Renegotiating = %d, anonpost = %d, plainfd = %d, cryptfd = %d, flags = 0x%x, session = 0x%x, got_session = %d, lid = \"%s\", rid = \"%s\"\n", renegotiating, anonpost, plainfd, cryptfd, cmd->cmd.pio_data.pioc_starttls.flags, session, got_session, cmd->cmd.pio_data.pioc_starttls.localid, cmd->cmd.pio_data.pioc_starttls.remoteid);
+fprintf (stderr, "DEBUG: Renegotiating = %d, anonpost = %d, plainfd = %d, cryptfd = %d, flags = 0x%x, session = %p, got_session = %d, lid = \"%s\", rid = \"%s\"\n", renegotiating, anonpost, plainfd, cryptfd, cmd->cmd.pio_data.pioc_starttls.flags, session, got_session, cmd->cmd.pio_data.pioc_starttls.localid, cmd->cmd.pio_data.pioc_starttls.remoteid);
 
 	//
 	// If this is server renegotiating, send a request to that end
@@ -4563,7 +4563,7 @@ fprintf (stderr, "DEBUG: Client-side invocation flagged as wrong; compensated er
 			close (plainfd);
 			plainfd = -1;
 		}
-fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
+fprintf (stderr, "ctlkey_unregister under ckn=%p at %d\n", (void *)ckn, __LINE__);
 		if (ckn != NULL) {	/* TODO: CHECK NEEDED? */
 			if (ctlkey_unregister (ckn->regent.ctlkey)) {
 				free (ckn);
@@ -4634,7 +4634,7 @@ fprintf (stderr, "DEBUG: anonpre_determination, comparing [%d] %s to %s, found c
 			close (plainfd);
 			plainfd = -1;
 		}
-fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
+fprintf (stderr, "ctlkey_unregister under ckn=%p at %d\n", (void *)ckn, __LINE__);
 		if (ckn != NULL) { /* TODO: CHECK NEEDED? */
 			if (ctlkey_unregister (ckn->regent.ctlkey)) {
 				free (ckn);
@@ -4808,7 +4808,7 @@ if (renegotiating) {
 			send_error (replycmd, EIO, "Failed to prepare for TLS");
 		}
 		if (got_session) {
-fprintf (stderr, "gnutls_deinit (0x%x) at %d\n", session, __LINE__);
+fprintf (stderr, "gnutls_deinit (%p) at %d\n", (void *)session, __LINE__);
 			gnutls_deinit (session);
 			got_session = 0;
 		}
@@ -4817,7 +4817,7 @@ fprintf (stderr, "gnutls_deinit (0x%x) at %d\n", session, __LINE__);
 			close (plainfd);
 			plainfd = -1;
 		}
-fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
+fprintf (stderr, "ctlkey_unregister under ckn=%p at %d\n", (void *)ckn, __LINE__);
 		if (ckn != NULL) {	/* TODO: CHECK NEEDED? */
 			if (ctlkey_unregister (ckn->regent.ctlkey)) {
 				free (ckn);
@@ -4991,7 +4991,7 @@ fprintf (stderr, "DEBUG: Prior to valexp, gtls_errno = %d\n", gtls_errno);
 		// Setup for validation expression runthrough
 		cmd->valexp_result = -1;
 		if ((cmd->trust_valexp != NULL) && (0 != strcmp (cmd->trust_valexp, "1"))) {
-fprintf (stderr, "DEBUG: Trust valexp \"%s\" @ 0x%016x\n", cmd->trust_valexp, (uint64_t) cmd->trust_valexp);
+fprintf (stderr, "DEBUG: Trust valexp \"%s\" @ %p\n", cmd->trust_valexp, (void *) cmd->trust_valexp);
 			valexp_conj [valexp_conj_count++] = cmd->trust_valexp;
 		}
 		if (cmd->lids [LID_TYPE_VALEXP - LID_TYPE_MIN].data != NULL) {
@@ -5006,7 +5006,7 @@ fprintf (stderr, "DEBUG: Trust valexp \"%s\" @ 0x%016x\n", cmd->trust_valexp, (u
 				&lid_valexp,
 				&ignored.data,
 				&ignored.size);
-fprintf (stderr, "DEBUG: LocalID valexp \"%s\" @ 0x%016x (ok=%d)\n", lid_valexp, (uint64_t) lid_valexp, ok);
+fprintf (stderr, "DEBUG: LocalID valexp \"%s\" @ %p (ok=%d)\n", lid_valexp, (void *) lid_valexp, ok);
 			if (ok && (lid_valexp != NULL)) {
 				valexp_conj [valexp_conj_count++] = lid_valexp;
 			} else {
@@ -5021,7 +5021,7 @@ fprintf (stderr, "DEBUG: Number of valexp is %d, gtls_errno=%d\n", valexp_conj_c
 				valexp_conj,
 				have_starttls_validation (),
 				(void *) cmd);
-fprintf (stderr, "DEBUG: Registered to verun = 0x%016x\n", (uint64_t) verun);
+fprintf (stderr, "DEBUG: Registered to verun = %p\n", (void *) verun);
 			if (verun == NULL) {
 				gtls_errno = GNUTLS_E_AUTH_ERROR;
 			}
@@ -5039,7 +5039,7 @@ fprintf (stderr, "DEBUG: valexp returns NEGATIVE result\n");
 			}
 else fprintf (stderr, "DEBUG: valexp returns POSITIVE result\n");
 			valexp_unregister (verun);
-fprintf (stderr, "DEBUG: Unregistered verun 0x%016x\n", (uint64_t) verun);
+fprintf (stderr, "DEBUG: Unregistered verun %p\n", (void *) verun);
 		}
 	}
 
@@ -5047,7 +5047,7 @@ fprintf (stderr, "DEBUG: Unregistered verun 0x%016x\n", (uint64_t) verun);
 	// Cleanup any prefetched identities
 	for (i=LID_TYPE_MIN; i<=LID_TYPE_MAX; i++) {
 		if (cmd->lids [i - LID_TYPE_MIN].data != NULL) {
-fprintf (stderr, "DEBUG: Freeing cmd->lids[%d].data 0x%016x\n", i-LID_TYPE_MIN, cmd->lids [i-LID_TYPE_MIN].data);
+fprintf (stderr, "DEBUG: Freeing cmd->lids[%d].data %p\n", i-LID_TYPE_MIN, (void *)(cmd->lids [i-LID_TYPE_MIN].data));
 			free (cmd->lids [i - LID_TYPE_MIN].data);
 		}
 	}
@@ -5123,7 +5123,7 @@ fprintf (stderr, "DEBUG: Freeing cmd->lids[%d].data 0x%016x\n", i-LID_TYPE_MIN, 
 			free (preauth);
 		}
 		if (got_session) {
-fprintf (stderr, "gnutls_deinit (0x%x) at %d\n", session, __LINE__);
+fprintf (stderr, "gnutls_deinit (%p) at %d\n", (void *)session, __LINE__);
 			gnutls_deinit (session);
 			got_session = 0;
 		}
@@ -5132,7 +5132,7 @@ fprintf (stderr, "gnutls_deinit (0x%x) at %d\n", session, __LINE__);
 			close (plainfd);
 			plainfd = -1;
 		}
-fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
+fprintf (stderr, "ctlkey_unregister under ckn=%p at %d\n", (void *)ckn, __LINE__);
 		if (ckn != NULL) {	/* TODO: CHECK NEEDED? */
 			if (ctlkey_unregister (ckn->regent.ctlkey)) {
 				free (ckn);
@@ -5163,12 +5163,12 @@ fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
 				free (preauth);
 			}
 			if (got_session) {
-fprintf (stderr, "gnutls_deinit (0x%x) at %d\n", session, __LINE__);
+fprintf (stderr, "gnutls_deinit (%p) at %d\n", (void *)session, __LINE__);
 				gnutls_deinit (session);
 				got_session = 0;
 			}
 			close (cryptfd);
-fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
+fprintf (stderr, "ctlkey_unregister under ckn=%p at %d\n", (void *)ckn, __LINE__);
 			if (ckn) {	/* TODO: CHECK NEEDED? PRACTICE=>YES */
 				if (ctlkey_unregister (ckn->regent.ctlkey)) {
 					free (ckn);
@@ -5191,12 +5191,12 @@ fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
 			free (preauth);
 		}
 		if (got_session) {
-fprintf (stderr, "gnutls_deinit (0x%x) at %d\n", session, __LINE__);
+fprintf (stderr, "gnutls_deinit (%p) at %d\n", (void *)session, __LINE__);
 			gnutls_deinit (session);
 			got_session = 0;
 		}
 		close (cryptfd);
-fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
+fprintf (stderr, "ctlkey_unregister under ckn=%p at %d\n", (void *)ckn, __LINE__);
 		if (ckn != NULL) {	/* TODO: CHECK NEEDED? */
 			if (ctlkey_unregister (ckn->regent.ctlkey)) {
 				free (ckn);
@@ -5286,7 +5286,7 @@ fprintf (stderr, "DEBUG: Goto renegotiate with cmd.lid = \"%s\" and orig_cmd.lid
 			// already have been freed if the ctlfd was closed
 			// and the connection could not continue detached
 			// (such as after forking it).
-fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
+fprintf (stderr, "ctlkey_unregister under ckn=%p at %d\n", (void *)ckn, __LINE__);
 			if (ctlkey_unregister (orig_starttls.ctlkey)) {
 				free (ckn);
 			}
@@ -5304,7 +5304,7 @@ fprintf (stderr, "ctlkey_unregister under ckn=0x%x at %d\n", ckn, __LINE__);
 	close (cryptfd);
 	cleanup_any_remote_credentials (cmd);
 	if (got_session) {
-fprintf (stderr, "gnutls_deinit (0x%x) at %d\n", session, __LINE__);
+fprintf (stderr, "gnutls_deinit (%p) at %d\n", (void *)session, __LINE__);
 		gnutls_deinit (session);
 		got_session = 0;
 	}

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -3658,7 +3658,7 @@ gtls_error fetch_local_credentials (struct command *cmd) {
 fprintf (stderr, "DEBUG: otfcert retrieval returned %d\n", gtls_errno);
 			return gtls_errno;
 		} else {
-fprintf (stderr, "DEBUG: otfcert retrieval returned GNUTLS_E_AGAIN, so skip it\n", gtls_errno);
+fprintf (stderr, "DEBUG: otfcert retrieval returned GNUTLS_E_AGAIN, so skip it\n");
 			gtls_errno = GNUTLS_E_SUCCESS;  // Attempt failed, ignore
 		}
 	}

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -5555,7 +5555,7 @@ gtls_error certificate_onthefly (struct command *cmd) {
 			// This is as expected, now .size will have been set
 			gtls_errno = GNUTLS_E_SUCCESS;
 		} else {
-			if (gtls_errno = GNUTLS_E_SUCCESS) {
+			if (gtls_errno == GNUTLS_E_SUCCESS) {
 				// Something must be wrong if we receive OK
 				gtls_errno = GNUTLS_E_INVALID_REQUEST;
 			}

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -131,7 +131,7 @@ static struct credinfo srv_creds [EXPECTED_SRV_CREDCOUNT];
 static struct credinfo cli_creds [EXPECTED_CLI_CREDCOUNT];
 static int srv_credcount = 0;
 static int cli_credcount = 0;
-static const char const *onthefly_p11uri = "pkcs11:manufacturer=ARPA2.net;token=TLS+Pool+internal;object=on-the-fly+signer;type=private;serial=1";
+static const char onthefly_p11uri[] = "pkcs11:manufacturer=ARPA2.net;token=TLS+Pool+internal;object=on-the-fly+signer;type=private;serial=1";
 static unsigned long long onthefly_serial;  //TODO: Fill with now * 1000
 static gnutls_x509_crt_t onthefly_issuercrt = NULL;
 static gnutls_privkey_t onthefly_issuerkey = NULL;

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -4267,6 +4267,10 @@ static void cleanup_starttls_credentials (void) {
 		case GNUTLS_CRD_SRP:
 			gnutls_srp_free_server_credentials (crd->cred);
 			break;
+		case GNUTLS_CRD_PSK:
+		case GNUTLS_CRD_IA:
+			//TODO: not handled
+			break;
 		//TODO// case GNUTLS_CRD_KDH:
 		//TODO// 	gnutls_kdh_free_server_credentials (crd->cred);
 		//TODO// 	break;
@@ -4284,6 +4288,10 @@ static void cleanup_starttls_credentials (void) {
 			break;
 		case GNUTLS_CRD_SRP:
 			gnutls_srp_free_client_credentials (crd->cred);
+			break;
+		case GNUTLS_CRD_PSK:
+		case GNUTLS_CRD_IA:
+			//TODO: not handled
 			break;
 		//TODO// case GNUTLS_CRD_KDH:
 		//TODO// 	gnutls_kdh_free_client_credentials (crd->cred);

--- a/src/trust.c
+++ b/src/trust.c
@@ -54,7 +54,7 @@ int trust_interpret (DBT *trustentry, uint32_t *flags, char **valexp, uint8_t **
 		// No room for the flags and mininal valexplen 1 + NUL
 		return TAD_STATUS_INVALID;
 	}
-	valexplen = strnlen (trustentry__data + 4, trustentry->size - 4);
+	valexplen = strnlen ((const char *)(trustentry__data + 4), trustentry->size - 4);
 	if (valexplen == 0) {
 		// Empty string is a syntax error
 		return TAD_STATUS_INVALID;
@@ -64,7 +64,7 @@ int trust_interpret (DBT *trustentry, uint32_t *flags, char **valexp, uint8_t **
 		return TAD_STATUS_INVALID;
 	}
 	*flags = ntohl (* (uint32_t *) trustentry__data);
-	*valexp = trustentry__data + 4;
+	*valexp = (char *)(trustentry__data + 4);
 	*trustdata    = trustentry__data + 4 + valexplen + 1;
 	*trustdatalen = trustentry->size - 4 - valexplen - 1;
 	return TAD_STATUS_SUCCESS;

--- a/src/validate.c
+++ b/src/validate.c
@@ -712,7 +712,7 @@ static int expand_cases_rec (char *valexpstr, int vallen, int invert, int *parse
 		// Post: #0;#1;#2;???=run[runlen];???[tbc];???
 		case0p = count_cases (valexpstr, vallen, 0, &pars0);
 		case0n = count_cases (valexpstr, vallen, 1, &pars0);
-		if (stacktop & (zero_1st | zero_2nd) == (zero_1st & zero_2nd)) {
+		if ((stacktop & (zero_1st | zero_2nd)) == (zero_1st | zero_2nd)) {
 			// Note, need &pars1 below when zero_2nd is false
 			case1 = 0;
 		} else {

--- a/src/validate.c
+++ b/src/validate.c
@@ -35,6 +35,7 @@
 static char valexp_varchars [] = "LlIiFfAaTtDdRrEeOoGgPpUuSsCc";
 static int valexp_char_bitnum [128];
 typedef uint32_t valexpreqs_t;
+
 #define VALEXP_CHARBIT(c)  (valexp_char_bitnum [(c)])
 #define VALEXP_CHARKNOWN(c) (((c) >= 0) && ((c) < 128) && (VALEXP_CHARBIT((c)) >= 0))
 #define VALEXP_OPERAND(c) (((c) == '0') || ((c) == '1') || (VALEXP_CHARKNOWN((c))))
@@ -202,7 +203,7 @@ static int count_cases (char *valexpstr, int vallen, int invert, int *parsed) {
 		return -1;
 	}
 	vallen--;
-	opcp = &valexpstr [vallen];
+	opcp = (uint8_t *)(&valexpstr [vallen]);
 	opc = *opcp;
 	switch (opc) {
 	case '&':
@@ -293,7 +294,7 @@ static int count_cases (char *valexpstr, int vallen, int invert, int *parsed) {
 			return 1;
 		}
 	default:
-		if (VALEXP_OPERAND (valexpstr [vallen])) {
+		if (VALEXP_OPERAND ((uint8_t)(valexpstr [vallen]))) {
 			*parsed = 1;
 			return 1;
 		} else {
@@ -944,7 +945,7 @@ int valexp_handling_index (char flag) {
 fprintf (stderr, "DEBUG: Returning from valexp_handling_index() with special-value flag 0\n");
 		return strlen (valexp_varchars);
 	}
-	assert (VALEXP_CHARKNOWN (flag));
+	assert (VALEXP_CHARKNOWN ((uint8_t)flag));
 fprintf (stderr, "DEBUG: Returning from valexp_handling_index() for flag '%c' with character bit value %d\n", flag, VALEXP_CHARBIT (flag));
 	return VALEXP_CHARBIT (flag);
 }
@@ -1125,7 +1126,7 @@ void valexp_setpredicate (struct valexp *ve, char predicate, bool value) {
 #ifdef DEBUG
 	assert (pthread_equal (ve->registering_thread, pthread_self ()));
 #endif
-	if (!VALEXP_CHARKNOWN (predicate)) {
+	if (!VALEXP_CHARKNOWN ((uint8_t)predicate)) {
 		// Nice try... ignore (but think twice about trusting that caller)
 		return;
 	}

--- a/src/validate.c
+++ b/src/validate.c
@@ -182,7 +182,7 @@ void cleanup_validate (void) {
  * that it should not be made to work on constant strings, but it can
  * be made to work on the same (global/static) variables repeatedly or
  * even concurrently; it is designed to be idempotent and re-entrant.
- * 
+ *
  * On success, the function fills the parsed value with the number
  * of characters that were parsed (in a range of 0 up to vallen)
  * starting from the end of the expression -- since it is reverse
@@ -528,7 +528,7 @@ static int explicit_interleave (struct valexp_case *accu,   int acculen,
  * has two & operands.  Inversion applied to ? is passed inward.  After
  * having been inverted if needed, the ? operator is translated into the
  * normal sum and product operators.
- * 
+ *
  * The most complex operation is the interleaving caused by products; all
  * combinations of the operand cases must be combined to form the outcome
  * cases, and the individual constraints must be combined to form a more
@@ -567,7 +567,7 @@ static int explicit_interleave (struct valexp_case *accu,   int acculen,
  * A sum initiates the remaining space by setting it all to zero, to signify
  * TRUE.  It then applies its first operand, and learns about the end point.
  * Then it clears the remaining space after this end point, and applies the
- * second operand starting in its beginning.  Both cases are started with 
+ * second operand starting in its beginning.  Both cases are started with
  * run length 1.  The sum operation returns as its number of cases the sum
  * of the number of cases from its operands.
  *
@@ -874,7 +874,7 @@ static int expand_cases_rec (char *valexpstr, int vallen, int invert, int *parse
 				0, &pars0,
 				ve, offset, runlen * case1, 0 /*TODO:REALLY0?*/));
 		}
-		// 
+		//
 		// Interleave i-[case0n] into #1
 		// Pre:  #0 = run*t*i+[sz0]
 		//	 #1 = run*e[runlen*case2<sz1]

--- a/src/validate.c
+++ b/src/validate.c
@@ -111,14 +111,11 @@ struct valexp {
  * unhandy valexp_varchars to a direct char-to-bitnum map.
  */
 void setup_validate (void) {
-	int i;
-	for (i=0; i < 128; i++) {
+	for (unsigned int i=0; i < 128; i++) {
 		valexp_char_bitnum [i] = -1;
 	}
-	i = 0;
-	while (valexp_varchars [i]) {
-		assert (i < 32);
-		valexp_char_bitnum [valexp_varchars [i]] = i++;
+	for (unsigned int i=0; (i < 32) && valexp_varchars[i]; ++i) {
+		valexp_char_bitnum [valexp_varchars [i]] = i;
 	}
 }
 

--- a/test/escaping.c
+++ b/test/escaping.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <string.h>
+
+/* from online.c */
+int strncatesc (char *dst, int dstlen, char *src, char srcend, char *escme) ;
+
+typedef struct {
+	char *src;
+	char *expected;
+} testcase;
+
+const char escape[] = "\\+,\"<=># ;";
+const testcase cases[] = {
+	{ "", "" },
+	{ "abc", "abc" },
+	{ "x+y", "x\\2by" },
+	{ NULL, NULL }
+} ;
+
+int main(int argc, char **argv)
+{
+	char outbuf[128];
+	int count = 0;
+
+	const testcase *t = cases;
+	while (t->src != NULL)
+	{
+		memset(outbuf, 0, sizeof(outbuf));
+		(void) strncatesc(outbuf, sizeof(outbuf), t->src, 0, escape);
+		if (strcmp(outbuf, t->expected) == 0)
+		{
+			printf("Case %d '%s' OK.\n", count, t->src);
+		}
+		else
+		{
+			printf("Case %d '%s' FAILED.\n", count, t->src);
+			printf("Expeced: '%s'\n", t->expected);
+			printf("Found  : '%s'\n", outbuf);
+		}
+
+		t++;
+		count++;
+	}
+
+	return 0;
+}
+


### PR DESCRIPTION
This is a long list of small fixes to make TLSPool build on FreeBSD (with the Makefile) with clang, reducing the number of compile warnings:

 - fix pkg-config invocation for Quick-DER
 - allow FreeBSD packages to be found
 - allow building without gnutls-kdh	6cb9ad0
 - fix typo'ed gnutls function name 	a380b8f
 - lots of C-style things:
   - drop trailing spaces
   - assignment from char * to uint8_t * and back made explicit

Actual bugfixes
   - using %p for printing pointers
   - logic error in validation expression 	fce88ca
   - string-escaping didn't escape 	84a7424
   - assignment in if	c44358c