### PR TITLE
miscellaneous fixes to compile tlspool again on windows 

### DIFF
--- a/include/windows/syslog.h
+++ b/include/windows/syslog.h
@@ -52,4 +52,6 @@ openlog(const char *ident, int logopt, int facility);
 void
 syslog(int priority, const char *message, ...);
 
+void
+vsyslog(int priority, const char *format, va_list ap);
 #endif

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -25,7 +25,7 @@ PREFIX ?= /usr/local
 
 ifdef WINVER
 # TODO libtlspool_lidentry and libtlspool_pinentry
-libtlspool_OBJS = libtlspool.o
+libtlspool_OBJS = libtlspool.o libtlspool_configvar.o
 else
 libtlspool_OBJS = libtlspool.o libtlspool_lidentry.o libtlspool_pinentry.o libtlspool_configvar.o
 endif

--- a/lib/libtlspool.c
+++ b/lib/libtlspool.c
@@ -708,7 +708,11 @@ static int socket_dup_protocol_info(int fd, int pid, LPWSAPROTOCOL_INFOW lpProto
  * converts IPPROTO_* to SOCK_*, returns -1 if invalid protocol
  */
 static int ipproto_to_sockettype(uint8_t ipproto) {
+#ifndef WINDOWS_PORT
 	return ipproto == IPPROTO_TCP ? SOCK_STREAM : ipproto == IPPROTO_UDP ? SOCK_DGRAM : ipproto == IPPROTO_SCTP ? SOCK_SEQPACKET : -1;
+#else /* WINDOWS_PORT */
+	return ipproto == IPPROTO_TCP ? SOCK_STREAM : ipproto == IPPROTO_UDP ? SOCK_DGRAM : -1;
+#endif /* WINDOWS_PORT */
 }
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,13 +40,6 @@ KERBEROS_CFLAGS = $(shell krb5-config --cflags)
 KERBEROS_LIBS = $(shell krb5-config --libs)
 # CFLAGS += -DHAVE_TLS_KDH
 
-ifdef WINVER
-CFLAGS += -D_WIN32_WINNT=0x0600 -DATTRIBUTE_UNUSED="" -I ../include/windows
-OBJS += windows/syslog.o windows/windows.o windows/getopt.o
-LIBS += -lkernel32 -ladvapi32 -lmsvcrt -lwsock32 -lws2_32
-EXE = .exe
-endif
-
 PKG_CONFIG ?= pkg-config
 
 ifdef WINVER

--- a/src/starttls.c
+++ b/src/starttls.c
@@ -31,12 +31,14 @@
 
 #include <libtasn1.h>
 
+
+#ifdef HAVE_TLS_KDH
 #include <krb5.h>
 /* Plus, from k5-int.h: */
 krb5_error_code KRB5_CALLCONV krb5_decrypt_tkt_part(krb5_context,
                                                     const krb5_keyblock *,
                                                     krb5_ticket * );
-
+#endif
 
 #include <quick-der/api.h>
 #include <quick-der/rfc4120.h>


### PR DESCRIPTION
Perhaps wait for merging to include socketpair fix etc.

Changes:
- vsyslog prototype
- libtlspool_configvar dependency
- IPPROTO_SCTP not available on windows
- HAVE_TLS_KDH in starttls.c
