### PR TITLE
ca signed certs, fixed web templates

### DIFF
--- a/testdata/Makefile
+++ b/testdata/Makefile
@@ -252,15 +252,15 @@ tlspool-test-server-pubkey.pgp:
 	$(CERTTOOL) --pgp-certificate-info --infile $@ --inraw --outfile $(@:.pgp=.asc)
 
 # Key 3: X.509 Client Certificate
-tlspool-test-client-cert.der: tlspool-test-client-cert.template
+tlspool-test-client-cert.der: tlspool-test-client-cert.template tlspool-test-ca-cert.der
 	echo Using PRIVKEY3, '$(PRIVKEY3)'
-	$(CERTTOOL) --outfile $@ --outder --generate-self-signed --load-privkey='$(PRIVKEY3)' --template=$<
+	$(CERTTOOL) --outfile $@ --outder --generate-certificate --load-ca-certificate=tlspool-test-ca-cert.pem --load-ca-privkey='$(PRIVKEY5)' --load-privkey='$(PRIVKEY3)' --template=$<
 	$(CERTTOOL) --certificate-info --infile $@ --inder --outfile $(@:.der=.pem)
 
 # Key 4: X.509 Server Certificate with user@ domain name
-tlspool-test-server-cert.der: tlspool-test-server-cert.template
+tlspool-test-server-cert.der: tlspool-test-server-cert.template tlspool-test-ca-cert.der
 	echo Using PRIVKEY4, '$(PRIVKEY4)'
-	$(CERTTOOL) --outfile $@ --outder --generate-self-signed --load-privkey='$(PRIVKEY4)' --template=$<
+	$(CERTTOOL) --outfile $@ --outder --generate-certificate --load-ca-certificate=tlspool-test-ca-cert.pem --load-ca-privkey='$(PRIVKEY5)' --load-privkey='$(PRIVKEY4)' --template=$<
 	$(CERTTOOL) --certificate-info --infile $@ --inder --outfile $(@:.der=.pem)
 
 # Key 5: Test CA (for chained certificates)
@@ -281,14 +281,14 @@ tlspool-test-flying-signer.der: tlspool-test-flying-signer.template
 	$(CERTTOOL) --certificate-info --infile $@ --inder --outfile $(@:.der=.pem)
 
 # Key 7: X.509 Server Certificate with just a host name
-tlspool-test-webhost-cert.der: tlspool-test-webhost-cert.template
+tlspool-test-webhost-cert.der: tlspool-test-webhost-cert.template tlspool-test-ca-cert.der
 	echo Using PRIVKEY7, '$(PRIVKEY7)'
-	$(CERTTOOL) --outfile $@ --outder --generate-self-signed --load-privkey='$(PRIVKEY7)' --template=$<
+	$(CERTTOOL) --outfile $@ --outder --generate-certificate --load-ca-certificate=tlspool-test-ca-cert.pem --load-ca-privkey='$(PRIVKEY5)' --load-privkey='$(PRIVKEY7)' --template=$<
 
 # Key 8: X.509 Server Certificate with just a host name
-tlspool-test-playground-cert.der: tlspool-test-playground-cert.template
+tlspool-test-playground-cert.der: tlspool-test-playground-cert.template tlspool-test-ca-cert.der
 	echo Using PRIVKEY8, '$(PRIVKEY8)'
-	$(CERTTOOL) --outfile $@ --outder --generate-self-signed --load-privkey='$(PRIVKEY8)' --template=$<
+	$(CERTTOOL) --outfile $@ --outder --generate-certificate --load-ca-certificate=tlspool-test-ca-cert.pem --load-ca-privkey='$(PRIVKEY5)' --load-privkey='$(PRIVKEY8)' --template=$<
 
 
 # Turn a .der into a .keyid

--- a/testdata/tlspool-test-ca-cert.template
+++ b/testdata/tlspool-test-ca-cert.template
@@ -135,7 +135,7 @@ crl_signing_key
 #code_signing_key
 
 # Whether this key will be used to sign OCSP data.
-ocsp_signing_key
+#ocsp_signing_key
 
 # Whether this key will be used for time stamping.
 #time_stamping_key

--- a/testdata/tlspool-test-playground-cert.template
+++ b/testdata/tlspool-test-playground-cert.template
@@ -18,7 +18,7 @@ state = "Freedom"
 # country = GR
 
 # The common name of the certificate owner.
-cn = "TLS Pool Test X.509 Server"
+cn = "TLS Pool Test X.509 Playground Server"
 
 # A user id of the certificate owner.
 #uid = "clauper"
@@ -118,15 +118,6 @@ encryption_key
 # Whether this certificate will be used for a TLS server
 tls_www_server
 
-# Whether this certificate will be used to sign data (needed
-# in TLS DHE ciphersuites).
-signing_key
-
-# Whether this certificate will be used to encrypt data (needed
-# in TLS RSA ciphersuites). Note that it is preferred to use different
-# keys for encryption and signing.
-encryption_key
-
 # Whether this key will be used to sign other certificates.
 # cert_signing_key
 
@@ -137,7 +128,7 @@ crl_signing_key
 #code_signing_key
 
 # Whether this key will be used to sign OCSP data.
-ocsp_signing_key
+#ocsp_signing_key
 
 # Whether this key will be used for time stamping.
 #time_stamping_key

--- a/testdata/tlspool-test-webhost-cert.template
+++ b/testdata/tlspool-test-webhost-cert.template
@@ -18,7 +18,7 @@ state = "Freedom"
 # country = GR
 
 # The common name of the certificate owner.
-cn = "TLS Pool Test X.509 Server"
+cn = "TLS Pool Test X.509 Webhost Server"
 
 # A user id of the certificate owner.
 #uid = "clauper"
@@ -31,7 +31,7 @@ cn = "TLS Pool Test X.509 Server"
 # any OID here.
 # For example set the X.520 Title and the X.520 Pseudonym
 # by using OID and string pairs.
-#dn_oid = 2.5.4.12 Dr. 
+#dn_oid = 2.5.4.12 Dr.
 #dn_oid = 2.5.4.65 jackal
 
 # This is deprecated and should not be used in new
@@ -41,10 +41,10 @@ cn = "TLS Pool Test X.509 Server"
 # An alternative way to set the certificate's distinguished name directly
 # is with the "dn" option. The attribute names allowed are:
 # C (country), street, O (organization), OU (unit), title, CN (common name),
-# L (locality), ST (state), placeOfBirth, gender, countryOfCitizenship, 
-# countryOfResidence, serialNumber, telephoneNumber, surName, initials, 
-# generationQualifier, givenName, pseudonym, dnQualifier, postalCode, name, 
-# businessCategory, DC, UID, jurisdictionOfIncorporationLocalityName, 
+# L (locality), ST (state), placeOfBirth, gender, countryOfCitizenship,
+# countryOfResidence, serialNumber, telephoneNumber, surName, initials,
+# generationQualifier, givenName, pseudonym, dnQualifier, postalCode, name,
+# businessCategory, DC, UID, jurisdictionOfIncorporationLocalityName,
 # jurisdictionOfIncorporationStateOrProvinceName,
 # jurisdictionOfIncorporationCountryName, XmppAddr, and numeric OIDs.
 
@@ -58,7 +58,7 @@ serial = 001
 # Use -1 if there is no expiration date.
 expiration_days = 70
 
-# Alternatively you may set concrete dates and time. The GNU date string 
+# Alternatively you may set concrete dates and time. The GNU date string
 # formats are accepted. See:
 # http://www.gnu.org/software/tar/manual/html_node/Date-input-formats.html
 
@@ -118,15 +118,6 @@ encryption_key
 # Whether this certificate will be used for a TLS server
 tls_www_server
 
-# Whether this certificate will be used to sign data (needed
-# in TLS DHE ciphersuites).
-signing_key
-
-# Whether this certificate will be used to encrypt data (needed
-# in TLS RSA ciphersuites). Note that it is preferred to use different
-# keys for encryption and signing.
-encryption_key
-
 # Whether this key will be used to sign other certificates.
 # cert_signing_key
 
@@ -137,7 +128,7 @@ crl_signing_key
 #code_signing_key
 
 # Whether this key will be used to sign OCSP data.
-ocsp_signing_key
+#ocsp_signing_key
 
 # Whether this key will be used for time stamping.
 #time_stamping_key
@@ -202,4 +193,3 @@ ocsp_signing_key
 # this is the 5th CRL by this CA
 # Comment the field for a time-based number.
 #crl_number = 5
-


### PR DESCRIPTION
- Alle certificaten ondertekend door  tlspool-test-ca-cert.der behalve 'flying signer'
- geen OCSP in CA
- webcertificaten tlspool.arpa2.lab en playground.arpa2.lab gefikst