### PR TITLE
correct configvar in lidentry and pinentry

### DIFF
--- a/lib/libtlspool_lidentry.c
+++ b/lib/libtlspool_lidentry.c
@@ -58,7 +58,7 @@ int tlspool_localid_service (char *path, uint32_t regflags, int responsetimeout,
 
 	/* Access the TLS Pool socket */
 	if (path == NULL) {
-		path = tlspool_configvar (NULL, "daemon_pidfile");
+		path = tlspool_configvar (NULL, "socket_name");
 	}
 	if (path == NULL) {
 		path = TLSPOOL_DEFAULT_SOCKET_PATH;

--- a/lib/libtlspool_pinentry.c
+++ b/lib/libtlspool_pinentry.c
@@ -60,7 +60,7 @@ int tlspool_pin_service (char *path, uint32_t regflags, int responsetimeout_usec
 
 	/* Access the TLS Pool socket */
 	if (path == NULL) {
-		path = tlspool_configvar (NULL, "daemon_pidfile");
+		path = tlspool_configvar (NULL, "socket_name");
 	}
 	if (path == NULL) {
 		path = TLSPOOL_DEFAULT_SOCKET_PATH;

--- a/src/service.c
+++ b/src/service.c
@@ -433,7 +433,7 @@ static void process_command (struct command *cmd) {
 	tlog (TLOG_UNIXSOCK, LOG_DEBUG, "Processing command 0x%08x, passfd=%d", cmd->cmd.pio_cmd, cmd->passfd);
 	union pio_data *d = &cmd->cmd.pio_data;
 	if (is_callback (cmd)) {
-printf ("DEBUG: Processing callback command sent over fd=%d\n", cmd->clientfd);
+tlog (TLOG_UNIXSOCK, LOG_DEBUG, "DEBUG: Processing callback command sent over fd=%d\n", cmd->clientfd);
 		post_callback (cmd);
 		return;
 	}
@@ -463,11 +463,9 @@ printf ("DEBUG: Processing callback command sent over fd=%d\n", cmd->clientfd);
 	case PIOC_CONTROL_REATTACH_V2:
 		ctlkey_reattach (cmd);
 		return;
-#ifndef WINDOWS_PORT
 	case PIOC_PINENTRY_V2:
 		register_pinentry_command (cmd);
 		return;
-#endif
 	case PIOC_LIDENTRY_REGISTER_V2:
 		register_lidentry_command (cmd);
 		return;


### PR DESCRIPTION
path should be set to the value of 'socket_name' instead of 'daemon_pidfile'