### PR TITLE
show local and remote id after tlspool_starttls return

### DIFF
--- a/tool/chatcli.c
+++ b/tool/chatcli.c
@@ -266,7 +266,7 @@ reconnect:
 	} else {
 		printf ("SIGCONT will trigger renegotiation of the TLS handshake\n");
 	}
-	printf ("DEBUG: Local plainfd = %d\n", plainfd);
+	printf ("DEBUG: Local plainfd = %d, localid = %s, remoteid = %s\n", plainfd, tlsdata_cli.localid, tlsdata_cli.remoteid);
 	runterminal (plainfd, &sigcont, &tlsdata_cli,
 			PIOF_STARTTLS_LOCALROLE_CLIENT | PIOF_STARTTLS_REMOTEROLE_SERVER | PIOF_STARTTLS_RENEGOTIATE,
 			"testcli@tlspool.arpa2.lab",

--- a/tool/chatsrv.c
+++ b/tool/chatsrv.c
@@ -321,7 +321,7 @@ reconnect:
 		} else {
 			printf ("SIGCONT will trigger renegotiation of the TLS handshake during a connection\n");
 		}
-		printf ("DEBUG: Local plainfd = %d\n", plainfd);
+		printf ("DEBUG: Local plainfd = %d, localid = %s, remoteid = %s\n", plainfd, tlsdata_now.localid, tlsdata_now.remoteid);
 		runterminal (plainfd, &sigcont, &tlsdata_now,
 				PIOF_STARTTLS_LOCALROLE_SERVER | PIOF_STARTTLS_REMOTEROLE_CLIENT | PIOF_STARTTLS_RENEGOTIATE,
 				"testsrv@tlspool.arpa2.lab",


### PR DESCRIPTION
dit komt er uit bij de server
```
tlspool-chat-server tlspool.arpa2.lab 127.0.0.1 12345
...
DEBUG: Local plainfd = 6, localid = , remoteid =
```
en ook bij de client
```
tlspool-chat-client tlspool.arpa2.lab 127.0.0.1 12345
...
DEBUG: Local plainfd = 5, localid = , remoteid =
```
Is dat een issue?